### PR TITLE
fix: add missed http_parser

### DIFF
--- a/src/aiohttp_zlib_ng/__init__.py
+++ b/src/aiohttp_zlib_ng/__init__.py
@@ -11,6 +11,7 @@ TARGETS = (
     "http_writer",
     "http_websocket",
     "http_writer",
+    "http_parser",
     "multipart",
     "web_response",
 )


### PR DESCRIPTION
The `aiohttp` version I was testing on we too new, and we need this to work for older versions as well since HA is still beheind