### PR TITLE
feat: make isal optional and installed only as an extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,13 @@ If `isal` is available, this library will try to use `isal`, and will fallback t
 
 ## Installation
 
-Install this via pip (or your favourite package manager):
+Install this via pip (or your favorite package manager):
 
 `pip install aiohttp-zlib-ng`
+
+To install the optional `isal` speed up:
+
+`pip install aiohttp-zlib-ng[isal]`
 
 ## Usage
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -123,21 +123,22 @@ files = [
 
 [[package]]
 name = "attrs"
-version = "23.1.0"
+version = "23.2.0"
 description = "Classes Without Boilerplate"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "attrs-23.1.0-py3-none-any.whl", hash = "sha256:1f28b4522cdc2fb4256ac1a020c78acf9cba2c6b461ccd2c126f3aa8e8335d04"},
-    {file = "attrs-23.1.0.tar.gz", hash = "sha256:6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015"},
+    {file = "attrs-23.2.0-py3-none-any.whl", hash = "sha256:99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1"},
+    {file = "attrs-23.2.0.tar.gz", hash = "sha256:935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30"},
 ]
 
 [package.extras]
 cov = ["attrs[tests]", "coverage[toml] (>=5.3)"]
-dev = ["attrs[docs,tests]", "pre-commit"]
+dev = ["attrs[tests]", "pre-commit"]
 docs = ["furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-towncrier", "towncrier", "zope-interface"]
 tests = ["attrs[tests-no-zope]", "zope-interface"]
-tests-no-zope = ["cloudpickle", "hypothesis", "mypy (>=1.1.1)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
+tests-mypy = ["mypy (>=1.6)", "pytest-mypy-plugins"]
+tests-no-zope = ["attrs[tests-mypy]", "cloudpickle", "hypothesis", "pympler", "pytest (>=4.3.0)", "pytest-xdist[psutil]"]
 
 [[package]]
 name = "colorama"
@@ -343,7 +344,7 @@ files = [
 name = "isal"
 version = "1.5.3"
 description = "Faster zlib and gzip compatible compression and decompression by providing python bindings for the ISA-L library."
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "isal-1.5.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9b4fcf4f63ec2b74999ae9cb836fc28d8dc36bec4e6a8e92b8eb45441f434ae9"},
@@ -502,13 +503,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pytest"
-version = "7.4.3"
+version = "7.4.4"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-7.4.3-py3-none-any.whl", hash = "sha256:0d009c083ea859a71b76adf7c1d502e4bc170b80a8ef002da5806527b9591fac"},
-    {file = "pytest-7.4.3.tar.gz", hash = "sha256:d989d136982de4e3b29dabcc838ad581c64e8ed52c11fbe86ddebd9da0818cd5"},
+    {file = "pytest-7.4.4-py3-none-any.whl", hash = "sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8"},
+    {file = "pytest-7.4.4.tar.gz", hash = "sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280"},
 ]
 
 [package.dependencies]
@@ -706,7 +707,10 @@ files = [
     {file = "zlib_ng-0.4.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:959f8951cb7a44df190cbd69327c3ea467b6d6398c448727ecdbd520b6c4ba14"},
 ]
 
+[extras]
+isal = ["isal"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "6657f77fa7e28d60d03e3fdf228b2b790d6b2540cc7aa0eeb8f34957eee17c33"
+content-hash = "821f40e602671f9a4d01737420ff264a37a283140097a1cfc151786fbb04aaec"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,11 +25,15 @@ packages = [
 python = "^3.8"
 aiohttp = ">=3.8.5"
 zlib-ng = ">=0.3.0"
-isal = {markers = "platform_machine == \"x86_64\" or platform_machine == \"AMD64\" or platform_machine == \"aarch64\" or platform_machine == \"arm64\"", version = ">=1.5.3"}
+isal = {version = ">=1.5.3", optional = true, markers = "platform_machine == \"x86_64\" or platform_machine == \"AMD64\" or platform_machine == \"aarch64\" or platform_machine == \"arm64\""}
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.0"
 pytest-cov = "^3.0"
+
+
+[tool.poetry.extras]
+isal = ["isal"]
 
 [tool.semantic_release]
 branch = "main"


### PR DESCRIPTION
We have problems detecting i686 during image builds because they are done on x86_64 machines. To avoid this issue isal is now an extra and needs to be installed as `pip install aiohttp-zlib-ng[isal]`