### PR TITLE
fix: suppress mypy errors on platforms where isal is not available

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,6 @@ mypy_path = "src/"
 no_implicit_optional = true
 show_error_codes = true
 warn_unreachable = true
-warn_unused_ignores = true
 exclude = [
     'setup.py',
 ]

--- a/src/aiohttp_zlib_ng/__init__.py
+++ b/src/aiohttp_zlib_ng/__init__.py
@@ -2,11 +2,17 @@ __version__ = "0.0.0"
 
 import importlib
 import zlib as zlib_original
+from typing import TYPE_CHECKING
 
 import aiohttp
 
+if TYPE_CHECKING:
+    from zlib_ng import zlib_ng as best_zlib
+
 try:
-    from isal import isal_zlib as best_zlib
+    from isal import (  # type: ignore
+        isal_zlib as best_zlib,
+    )
 except ImportError:
     from zlib_ng import zlib_ng as best_zlib
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,16 +2,23 @@ import zlib as zlib_original
 
 import aiohttp.http_websocket
 
-from aiohttp_zlib_ng import best_zlib, disable_zlib_ng, enable_zlib_ng
+from aiohttp_zlib_ng import disable_zlib_ng, enable_zlib_ng
+
+try:
+    from isal import (  # type: ignore
+        isal_zlib as expected_zlib,
+    )
+except ImportError:
+    from zlib_ng import zlib_ng as expected_zlib
 
 
 def test_enable_disable():
     """Test enable/disable."""
     assert aiohttp.http_websocket.zlib is zlib_original
     enable_zlib_ng()
-    assert aiohttp.http_websocket.zlib is best_zlib
+    assert aiohttp.http_websocket.zlib is expected_zlib
     disable_zlib_ng()
     assert aiohttp.http_websocket.zlib is zlib_original
     enable_zlib_ng()
-    assert aiohttp.http_websocket.zlib is best_zlib
+    assert aiohttp.http_websocket.zlib is expected_zlib
     disable_zlib_ng()


### PR DESCRIPTION
avoids the following on platforms where isal is not available
```
src/aiohttp_zlib_ng/__init__.py:9: error: Cannot find implementation or library stub for module named "isal"  [import-not-found]
src/aiohttp_zlib_ng/__init__.py:9: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
```